### PR TITLE
chore(renovate): enable automerge for minor/patch/digest updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,18 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "automerge": true,
+  "automergeType": "pr",
+  "automergeStrategy": "squash",
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "digest", "pinDigest"],
+      "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
   ]
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Active l'automerge Renovate pour les mises à jour **minor**, **patch** et **digest** dont la CI passe
- Les mises à jour **major** restent en revue manuelle
- La stratégie utilisée est `squash` via PR (cohérent avec le merge des PRs existantes)

## Contexte

La queue Renovate avait accumulé 10 PRs ouvertes (dont certaines vieilles de 26 mois). 9 ont été mergées manuellement aujourd'hui. Cette configuration évite que la situation se reproduise.

## Changement `renovate.json`

```json
"automerge": true,
"automergeType": "pr",
"automergeStrategy": "squash",
"packageRules": [
  { "matchUpdateTypes": ["minor", "patch", "digest", "pinDigest"], "automerge": true },
  { "matchUpdateTypes": ["major"], "automerge": false }
]
```

## Test plan

- [ ] Vérifier que la CI passe sur cette PR
- [ ] Fusionner et observer qu'une future PR Renovate minor/patch se merge automatiquement après CI verte

https://claude.ai/code/session_01CNSxrBL2vM4tCQehbZch71
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNSxrBL2vM4tCQehbZch71)_