### PR TITLE
fix(deps): pin jackson-databind to 2.22.1 (CVE-2026-54515)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
 
         <slf4j-jboss-logmanager.version>2.1.0.Final</slf4j-jboss-logmanager.version>
         <lombok.version>1.18.46</lombok.version>
+        <jackson-databind.version>2.22.1</jackson-databind.version>
     </properties>
 
     <dependencyManagement>
@@ -48,6 +49,15 @@
                 <version>${quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <!-- CVE-2026-54515 (GHSA-5jmj-h7xm-6q6v): quarkus-bom 3.37.2 pins jackson-databind
+                 2.22.0, which is vulnerable. Override to the patched 2.22.1 until the platform
+                 BOM catches up. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson-databind.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Résumé
Remédiation sécurité : la BOM Quarkus 3.37.2 (dernière version publiée à ce jour) pin `jackson-databind` en 2.22.0, version vulnérable à un contournement de désérialisation insensible à la casse de `@JsonIgnoreProperties` par propriété. Un override de dependencyManagement fixe la version transitive à 2.22.1 (patchée) en attendant que la BOM Quarkus intègre le correctif.

## Changements
| Paquet | Avant | Après | Type (semver) | CVE/Advisory | Breaking ? |
|--------|-------|-------|---------------|--------------|------------|
| com.fasterxml.jackson.core:jackson-databind (transitif, via quarkus-bom) | 2.22.0 | 2.22.1 | patch | CVE-2026-54515 / GHSA-5jmj-h7xm-6q6v (CVSS 5.3, moderate, CWE-915) | Non |

## Évaluation du risque
- Patch release (2.22.0 → 2.22.1), API-compatible avec `jackson-core`/`jackson-annotations` déjà gérés par la BOM Quarkus (2.22.0 / 2.22).
- Aucun changement de comportement fonctionnel attendu.
- Point de vigilance : la base de données OSV publiée pour cette advisory (GHSA-5jmj-h7xm-6q6v) contient encore, pour la plage `>= 2.22.0`, une entrée `affected` sans évènement `fixed` explicite — ce qui fait qu'un scan `osv-scanner` peut continuer à signaler `2.22.1` comme affecté. Le texte de l'advisory upstream ("Will be fixed in ... 2.22.1") et Maven Central (2.22.1 est la dernière version publiée, 2026-07-08) confirment que 2.22.1 est bien la version corrigée — c'est vraisemblablement une incohérence de données côté base OSV, pas un vrai résidu de vulnérabilité. Rien de plus récent n'est disponible sur Maven Central à ce jour.
- Ce correctif est isolé (paquet transitif unique, patch) pour permettre un merge rapide, conformément à la politique de remédiation de sécurité prioritaire.

## Vérification
- Build local : `mvn -pl quarkus-lambda,quarkus-lambda-api-gateway-rest -am test-compile` → SUCCESS.
- Tests : `mvn -pl quarkus-lambda,quarkus-lambda-api-gateway-rest -am test` → 1/1 tests passés (`RestApiDemoTest`), aucune régression.
- Résolution vérifiée : `mvn dependency:tree` confirme `com.fasterxml.jackson.core:jackson-databind:jar:2.22.1:compile`.
- Pipeline CI/CD : à vérifier après ouverture de la PR (build GitHub Actions `build`).

## Rollback
Retirer le bloc `dependencyManagement` ajouté pour `jackson-databind` et la propriété `jackson-databind.version` dans `pom.xml` (racine), ou `git revert` de ce commit.

---
Labels suggérés : `dependencies`, `security`

Note complémentaire (hors scope de ce correctif) : les workflows GitHub Actions (`.github/workflows/github-actions.yml`, `.github/actions/setup/action.yml`) référencent `actions/checkout@v7` et `actions/setup-java@v5` par tag mouvant plutôt que par SHA. Le pinning par digest n'a pas pu être appliqué ici faute d'accès à ces dépôts publics depuis cette session pour récupérer un SHA vérifié — signalé pour validation humaine, aucune valeur n'a été inventée.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EDhXeehSzrMWJLrk4SfFng)_