### PR TITLE
fix(deps): bump Quarkus BOM 3.37.4 et jackson-databind 2.22.1 (CVEs Netty + Jackson)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,11 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus-plugin.version>3.37.1</quarkus-plugin.version>
-        <quarkus.platform.version>3.37.2</quarkus.platform.version>
+        <quarkus.platform.version>3.37.4</quarkus.platform.version>
 
         <slf4j-jboss-logmanager.version>2.1.0.Final</slf4j-jboss-logmanager.version>
         <lombok.version>1.18.46</lombok.version>
+        <jackson-databind.version>2.22.1</jackson-databind.version>
     </properties>
 
     <dependencyManagement>
@@ -48,6 +49,14 @@
                 <version>${quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <!-- CVE fix: quarkus-bom 3.37.4 still pins jackson-databind 2.22.0.
+                 Override to 2.22.1, which fixes GHSA-5gvw-p9qm-jgwh and GHSA-5jmj-h7xm-6q6v. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson-databind.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Résumé
Remédiation sécurité : bump patch de `quarkus.platform.version` (3.37.2 → 3.37.4) et ajout d'un override `dependencyManagement` pour `jackson-databind` (2.22.0 → 2.22.1). Corrige 17 vulnérabilités détectées par `osv-scanner` sur les 3 `pom.xml` du repo.

## Changements
| Paquet | Avant | Après | Type (semver) | CVE/Advisory | Breaking ? |
|--------|-------|-------|---------------|--------------|------------|
| `io.quarkus:quarkus-bom` (`quarkus.platform.version`) | 3.37.2 | 3.37.4 | patch | — (release de maintenance, entraîne le bump transitif de Netty ci-dessous) | Non |
| `io.netty:netty-codec` | 4.1.135.Final | 4.1.136.Final (transitif via quarkus-bom) | patch | GHSA-558v-64gr-wgg4 (CVSS 8.7) | Non |
| `io.netty:netty-codec-http` | 4.1.135.Final | 4.1.136.Final (transitif) | patch | GHSA-4mp9-239f-g9hg, GHSA-6cqp-g7gg-8hr5, GHSA-6jqx-86gh-f27w (CVE-2026-55831), GHSA-gcjf-9mgh-3p7g, GHSA-jppx-w49h-x2qq, GHSA-mvh2-crg5-v77c, GHSA-q4f6-jm68-57ww | Non |
| `io.netty:netty-codec-http2` | 4.1.135.Final | 4.1.136.Final (transitif) | patch | GHSA-93wv-jw9v-4972, GHSA-c69g-56f8-xwqj | Non |
| `io.netty:netty-codec-dns` | 4.1.135.Final | 4.1.136.Final (transitif) | patch | GHSA-mfg7-5gfp-c4w3 | Non |
| `io.netty:netty-codec-haproxy` | 4.1.135.Final | 4.1.136.Final (transitif) | patch | GHSA-q6cq-mhr2-jmr5, GHSA-wh89-7897-x99h | Non |
| `com.fasterxml.jackson.core:jackson-databind` | 2.22.0 | 2.22.1 (override explicite `dependencyManagement`) | patch | GHSA-5gvw-p9qm-jgwh (CVSS 6.5), GHSA-5jmj-h7xm-6q6v / CVE-2026-54515 (CVSS 5.3) | Non |

## Évaluation du risque
- Bump 3.37.2 → 3.37.4 reste dans la même ligne mineure Quarkus (3.37.x), documenté par l'éditeur comme "maintenance release" (https://quarkus.io/blog/quarkus-3-37-4-released/) : pas de breaking change attendu.
- `quarkus-bom` 3.37.4 (et même 3.38.2, vérifié) pin toujours `jackson-databind` en 2.22.0 : un override explicite dans le `dependencyManagement` racine était nécessaire pour obtenir le correctif. Jackson 2.22.0 → 2.22.1 est un patch, compatible binaire avec le reste de la ligne 2.22.x (jackson-core/annotations restent en 2.22.0/2.22.x, testé et compilé avec succès).
- Les CVE Netty concernent principalement des DoS (boucle infinie sur flux bzip2 malformé, épuisement mémoire sur frames SPDY/HTTP2 malformées) — pertinent car `netty` est utilisé par `quarkus-resteasy`/`quarkus-vertx-http` dans `quarkus-lambda-api-gateway-rest`.
- Le module `quarkus-lambda` (sans REST/Netty) n'est concerné que par les 2 CVE `jackson-databind`.
- Aucune dépendance directe ajoutée, aucun downgrade, aucune version dépubliée utilisée.

## Vérification
Vérification locale (module par module, dans `/home/user/aws-lamdba-quarkus`) :
- `mvn -pl quarkus-lambda,quarkus-lambda-api-gateway-rest dependency:tree` → confirme la résolution de `netty-codec*:4.1.136.Final` et `jackson-databind:2.22.1` partout où ils apparaissaient avant en 4.1.135.Final / 2.22.0.
- `mvn -pl quarkus-lambda,quarkus-lambda-api-gateway-rest -am clean test` → `BUILD SUCCESS`, `Tests run: 2` (quarkus-lambda : `DemoLambdaTest`, `StreamLambdaTest`) + `Tests run: 1` (quarkus-lambda-api-gateway-rest : `RestApiDemoTest`), 0 échec/erreur.
- `osv-scanner scan source -r .` avant fix : 17 vulnérabilités (0 Critical, 6 High, 11 Medium) sur 7 paquets ; après fix : `No issues found`.
- Build natif (`-Dnative -Dquarkus.native.container-build=true`) non testé localement (nécessite un moteur de conteneurs pour GraalVM, indisponible dans ce sandbox) — couvert par le pipeline CI/CD ci-dessous.

Pipeline CI/CD : **vert** — run [#470](https://github.com/a-besson/aws-lamdba-quarkus/actions/runs/31781176842) (job `Build`, incluant la compilation native GraalVM des deux modules) terminé en succès (`conclusion: success`, ~6 min 15 s).

## Rollback
Revert de ce commit unique (`git revert`) ou restauration de `quarkus.platform.version` à `3.37.2` et suppression de l'override `jackson-databind` dans `pom.xml`.

Labels suggérés : dependencies, security
