### PR TITLE
fix(deps): bump Quarkus 3.37.2 → 3.39.0 et pin jackson-databind 2.22.1 (14 CVEs)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,18 @@
         <!-- app dependencies -->
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus-plugin.version>3.37.1</quarkus-plugin.version>
-        <quarkus.platform.version>3.37.2</quarkus.platform.version>
+        <quarkus-plugin.version>3.39.0</quarkus-plugin.version>
+        <quarkus.platform.version>3.39.0</quarkus.platform.version>
 
         <slf4j-jboss-logmanager.version>2.1.0.Final</slf4j-jboss-logmanager.version>
         <lombok.version>1.18.46</lombok.version>
+
+        <!--
+          Transitive pin: the Quarkus BOM resolves jackson-databind 2.22.0, which is
+          still affected by CVE-2026-54515 and CVE-2026-59889. Both are fixed in
+          2.22.1. Drop this pin once the platform BOM ships 2.22.1 or later.
+        -->
+        <jackson-databind.version>2.22.1</jackson-databind.version>
     </properties>
 
     <dependencyManagement>
@@ -50,6 +57,11 @@
                 <scope>import</scope>
             </dependency>
 
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson-databind.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.jboss.slf4j</groupId>
                 <artifactId>slf4j-jboss-logmanager</artifactId>


### PR DESCRIPTION
## Résumé

Remédiation sécurité de l'arbre de dépendances runtime : **248 artefacts scannés contre OSV, 14 advisories avant, 0 après**. Le bump de plateforme couvre les 12 CVE netty ; le pin jackson-databind couvre les 2 restantes.

## Changements

| Paquet | Avant | Après | Type (semver) | CVE/Advisory | Breaking ? |
|--------|-------|-------|---------------|--------------|------------|
| `quarkus.platform.version` / `quarkus-plugin.version` | 3.37.2 / 3.37.1 | 3.39.0 | minor | 12 CVE netty (voir ci-dessous) | Non |
| `com.fasterxml.jackson.core:jackson-databind` (pin transitif) | 2.22.0 | 2.22.1 | patch | CVE-2026-54515, CVE-2026-59889 | Non |

### CVE netty remédiées — 4.1.135.Final → 4.1.137.Final (via le BOM)

**netty-codec-http**
- `GHSA-6jqx-86gh-f27w` / CVE-2026-55831 — **HIGH** — SPDY SETTINGS frame count matérialise une map non bornée
- `GHSA-jppx-w49h-x2qq` / CVE-2026-56745 — **HIGH** — fuite ByteBuf dans `SpdyHttpDecoder` sur RST_STREAM (épuisement mémoire native)
- `GHSA-mvh2-crg5-v77c` / CVE-2026-55833 — **HIGH** — expansion zlib SPDY poursuivie après troncature `maxHeaderSize`
- `GHSA-8c42-7qj2-3j46` / CVE-2026-59903 — écrasement du header CORS `Vary` → cache poisoning / divulgation
- `GHSA-4mp9-239f-g9hg` / CVE-2026-59898 — handshaker WebSockets V07/V08 sans validation Connection/Upgrade
- `GHSA-6cqp-g7gg-8hr5` / CVE-2026-56746 — contournement de contrôle de sécurité via court-circuit CORS
- `GHSA-gcjf-9mgh-3p7g` / CVE-2026-59921 — injection CRLF via nom de fichier multipart
- `GHSA-q4f6-jm68-57ww` / CVE-2026-59899 — croissance non bornée de la file par connexion via pipelining HTTP/1.1

**netty-codec**
- `GHSA-558v-64gr-wgg4` / CVE-2026-59901 — **HIGH** — boucle infinie dans la machine à états RLE de `Bzip2Decoder`, fige le thread de l'event loop

**netty-codec-haproxy**
- `GHSA-q6cq-mhr2-jmr5` / CVE-2026-55851 — **HIGH** — collision de sentinelle signed-byte dans `HAProxyMessageDecoder`
- `GHSA-wh89-7897-x99h` / CVE-2026-59919 — injection CRLF protocole HAProxy V1 via adresse AF_UNIX

**netty-codec-http2**
- `GHSA-93wv-jw9v-4972` / CVE-2026-56819 — **HIGH** — fuite de refcount ByteBuf sur canal de décompresseur fermé
- `GHSA-c69g-56f8-xwqj` / CVE-2026-59900 — absence de déduplication du header Host en HTTP/2 → HTTP/1.x

**netty-codec-dns**
- `GHSA-mfg7-5gfp-c4w3` / CVE-2026-73508 — fuite mémoire dans le décodeur d'enregistrements DNS

### CVE jackson-databind remédiées — 2.22.0 → 2.22.1 (pin explicite)

- `GHSA-5jmj-h7xm-6q6v` / CVE-2026-54515 — la désérialisation insensible à la casse contourne `@JsonIgnoreProperties` par propriété
- `GHSA-5gvw-p9qm-jgwh` / CVE-2026-59889 — `@JsonView` contourné pour les propriétés conteneur `@JsonUnwrapped`

## Évaluation du risque

**Pourquoi 3.39.0 et pas 3.37.4** — le BOM 3.37.4 s'arrête à netty **4.1.136.Final**, qui laisse **CVE-2026-59903** ouverte (corrigée seulement en 4.1.137.Final). Vérifié en résolvant les deux BOM : `3.37.4 → netty-codec-http 4.1.136.Final`, `3.39.0 → 4.1.137.Final`. C'est la raison du choix de version, pas une préférence pour la dernière.

**Le pin jackson-databind** est une contrainte transitive uniquement — l'artefact est déjà au classpath via `quarkus-jackson`, aucune dépendance nouvelle n'est introduite. Il porte un commentaire indiquant de le retirer dès que le BOM plateforme livrera 2.22.1 ou plus, pour ne pas figer durablement une version en travers de la plateforme.

**Bump mineur, pas majeur** : 3.37 → 3.39 reste dans la ligne Quarkus 3.x, et Renovate proposait déjà 3.39.0 de son côté. Aucun changement de code applicatif n'a été nécessaire.

Point de vigilance pour la revue : `java.version` reste à 21 et les images de base Docker ne sont pas touchées par cette PR.

## Vérification

**Vérification locale** :

- `mvn -B -ntp clean verify` → **BUILD SUCCESS** (49 s), 3 modules
- Tests : **3/3 verts** — `DemoLambdaTest`, `StreamLambdaTest` (module `quarkus-lambda`), `RestApiDemoTest` (module `quarkus-lambda-api-gateway-rest`)
- Résolution confirmée par `mvn dependency:tree` : `netty-*:4.1.137.Final`, `jackson-databind:2.22.1`
- Re-scan OSV de l'arbre résolu après changement : **248 artefacts, 0 vulnérabilité connue** (14 avant)

**Pipeline CI/CD** : ✅ **vert**. Le job `Build` est passé sur `2a50a1d` en 6 min (19:18:35 → 19:24:35 UTC), conforme à la durée habituelle sur `main`. [Run 32407960185](https://github.com/a-besson/aws-lamdba-quarkus/actions/runs/32407960185)

C'est la vérification qui compte le plus ici : la CI lance `mvn clean install -Dnative -Dquarkus.native.container-build=true`, soit un build **natif GraalVM**, sensible à la configuration de réflexion — le point où un changement netty/jackson casserait s'il devait casser. Il n'était pas reproductible localement (pas de build natif dans l'environnement d'audit) ; il est vert en CI.

## Recoupement avec les PR existantes

Cette PR recoupe volontairement plusieurs PR ouvertes et les rend redondantes si elle est mergée :

- **#45** (`quarkus.platform.version` → 3.39.0) — même bump de plateforme, sans le pin jackson ; laisse CVE-2026-54515 et CVE-2026-59889 ouvertes
- **#42** (`quarkus-maven-plugin` → 3.39.0) — inclus ici, plugin et plateforme alignés sur la même version
- **#47** (BOM 3.37.4 + jackson 2.22.1) — laisse **CVE-2026-59903** ouverte, le BOM 3.37.4 s'arrêtant à netty 4.1.136.Final
- **#44** (pin jackson-databind 2.22.1 seul) — inclus ici

À l'inverse, **#43** et **#46** (tags Docker UBI) portent sur les images de base et restent pertinentes indépendamment.

## Rollback

Revert du commit unique : `quarkus.platform.version` revient à 3.37.2, `quarkus-plugin.version` à 3.37.1, et l'entrée `jackson-databind` de `dependencyManagement` disparaît. Aucun changement de code, aucun lockfile.

```bash
git revert 2a50a1d
```

Labels suggérés : `dependencies`, `security`